### PR TITLE
fix:解决mjRefresh使用rnoh realease版本编译报错问题

### DIFF
--- a/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
@@ -30,7 +30,7 @@ class RefreshNodeDelegate {
 public:
     virtual ~RefreshNodeDelegate() = default;
     virtual void onRefresh(){};
-    virtual void pullRefreshStateChange(int32_t state, float_t percent);
+    virtual void pullRefreshStateChange(int32_t state, float_t percent){};
 };
 
 namespace rnoh {


### PR DESCRIPTION
# Summary

- fix:解决mjRefresh使用rnoh realease版本编译报错问题

Close: #15 

## Checklist
- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
