### PR TITLE
fix:修复下拉刷新当推到顶部时触发的onPull状态

### DIFF
--- a/harmony/mjrefresh/src/main/cpp/MjRefreshNode.cpp
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshNode.cpp
@@ -72,9 +72,11 @@ namespace rnoh {
                 m_refreshNodeDelegate->onRefresh();
             }
         }
-
         if (eventType == ArkUI_NodeEventType::NODE_REFRESH_STATE_CHANGE && m_refreshNodeDelegate) {
             switch (eventArgs->i32) {
+            case 1: {
+                m_refreshingState = false;
+            }
             case 2:
             case 3:
             case 4: {
@@ -83,7 +85,12 @@ namespace rnoh {
             }
             }
         }
-
+        if (eventArgs->i32 == 3) {
+            m_refreshingState = true;
+        }
+        if (m_refreshingState) {
+           return;
+        }
         if (eventType == ArkUI_NodeEventType::NODE_REFRESH_ON_OFFSET_CHANGE && m_refreshNodeDelegate) {
             if (eventArgs->f32 > 0 && eventArgs->f32 <= 64) {
                 float_t percent = eventArgs[0].f32 / 64;

--- a/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
@@ -38,7 +38,7 @@ namespace rnoh {
     protected:
         RefreshNodeDelegate *m_refreshNodeDelegate;
         static constexpr float REFRESH_NODE_SIZE = 29;
-
+        bool m_refreshingState = false; //是否触发正在刷新状态 
     public:
         MjRefreshNode();
         ~MjRefreshNode();


### PR DESCRIPTION
# Summary

- fix:修复下拉刷新当推到顶部时触发的onPull状态
- Close: #24 

## Test Plan

 - 测试demo，当下拉刷新后正在刷新时推到顶部不会触发onPull状态，观察日志
 - 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
