### PR TITLE
refactor: 适配0.77，处理tsx文件无法问题以及事件名称定义规格对齐

### DIFF
--- a/MJRefresh.js
+++ b/MJRefresh.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as ReactNative from "react-native";
-import MJRefreshView, { finishRefreshCommands, beginRefreshCommands, NativeProps, VoidEventData, OnPullingEventData } from "./src/js/MJRefreshNativeComponent";
+import MJRefreshView, { Commands, NativeProps, VoidEventData, OnPullingEventData } from "./src/js/MJRefreshNativeComponent";
 import MJScrollView from './MJScrollView'
 import MJFlatlist from './MJFlatList'
 
@@ -28,7 +28,7 @@ class MJRefresh extends React.Component<NativeProps>  {
     ) => {
         console.log("--------------------enter finishRefresh function")
         if (this.mjRefreshRef) {
-            finishRefreshCommands.finishRefresh(
+            Commands.finishRefresh(
                 this.mjRefreshRef
             );
         }
@@ -38,7 +38,7 @@ class MJRefresh extends React.Component<NativeProps>  {
     ) => {
         console.log("--------------------enter beginRefresh function")
         if (this.mjRefreshRef) {
-            beginRefreshCommands.beginRefresh(
+            Commands.beginRefresh(
                 this.mjRefreshRef
             );
         }

--- a/MJScrollView.js
+++ b/MJScrollView.js
@@ -38,7 +38,7 @@ import Dimensions from "react-native/Libraries/Utilities/Dimensions";
 import dismissKeyboard from "react-native/Libraries/Utilities/dismissKeyboard";
 import Platform from "@react-native-oh/react-native-harmony/Libraries/Utilities/Platform";
 import Keyboard from "react-native/Libraries/Components/Keyboard/Keyboard";
-import TextInputState from "@react-native-oh/react-native-harmony/Libraries/Components/TextInput/TextInputState.harmony";
+import TextInputState from "@react-native-oh/react-native-harmony/Libraries/Components/TextInput/TextInputState";
 import View from "react-native/Libraries/Components/View/View";
 import AndroidHorizontalScrollContentViewNativeComponent from "react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollContentViewNativeComponent";
 import AndroidHorizontalScrollViewNativeComponent from "react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent";

--- a/harmony/mjrefresh/src/main/cpp/EventEmitters.cpp
+++ b/harmony/mjrefresh/src/main/cpp/EventEmitters.cpp
@@ -39,7 +39,7 @@ namespace facebook {
 namespace react {
 
 void MJRefreshEventEmitter::onRefresh(OnRefresh event) const {
-    dispatchEvent("onRefresh", [event = std::move(event)](jsi::Runtime &runtime) {
+    dispatchEvent("Refresh", [event = std::move(event)](jsi::Runtime &runtime) {
         auto payload = jsi::Object(runtime);
         return payload;
     });
@@ -47,7 +47,7 @@ void MJRefreshEventEmitter::onRefresh(OnRefresh event) const {
 
 
 void MJRefreshEventEmitter::onRefreshIdle(OnRefreshIdle $event) const {
-  dispatchEvent("onRefreshIdle", [](jsi::Runtime &runtime) {
+  dispatchEvent("RefreshIdle", [](jsi::Runtime &runtime) {
     auto $payload = jsi::Object(runtime);
     return $payload;
   });
@@ -55,7 +55,7 @@ void MJRefreshEventEmitter::onRefreshIdle(OnRefreshIdle $event) const {
 
 
 void MJRefreshEventEmitter::onReleaseToRefresh(OnReleaseToRefresh $event) const {
-  dispatchEvent("onReleaseToRefresh", [](jsi::Runtime &runtime) {
+  dispatchEvent("ReleaseToRefresh", [](jsi::Runtime &runtime) {
     auto $payload = jsi::Object(runtime);
     return $payload;
   });
@@ -63,7 +63,7 @@ void MJRefreshEventEmitter::onReleaseToRefresh(OnReleaseToRefresh $event) const 
 
 
 void MJRefreshEventEmitter::onPulling(OnPulling $event) const {
-  dispatchEvent("onPulling", [$event=std::move($event)](jsi::Runtime &runtime) {
+  dispatchEvent("Pulling", [$event=std::move($event)](jsi::Runtime &runtime) {
     auto $payload = jsi::Object(runtime);
     $payload.setProperty(runtime, "percent", $event.percent);
     return $payload;

--- a/harmony/mjrefresh/src/main/cpp/MJRefreshJSIBinder.h
+++ b/harmony/mjrefresh/src/main/cpp/MJRefreshJSIBinder.h
@@ -31,10 +31,10 @@ class MJRefreshJSIBinder : public ViewComponentJSIBinder {
     facebook::jsi::Object createDirectEventTypes(facebook::jsi::Runtime &rt) override
     {
         facebook::jsi::Object events(rt);
-        events.setProperty(rt, "topOnRefresh", createDirectEvent(rt, "onRefresh"));
-        events.setProperty(rt, "topOnRefreshIdle", createDirectEvent(rt, "onRefreshIdle"));
-        events.setProperty(rt, "topOnReleaseToRefresh", createDirectEvent(rt, "onReleaseToRefresh"));
-        events.setProperty(rt, "topOnPulling", createDirectEvent(rt, "onPulling"));
+        events.setProperty(rt, "topRefresh", createDirectEvent(rt, "onRefresh"));
+        events.setProperty(rt, "topRefreshIdle", createDirectEvent(rt, "onRefreshIdle"));
+        events.setProperty(rt, "topReleaseToRefresh", createDirectEvent(rt, "onReleaseToRefresh"));
+        events.setProperty(rt, "topPulling", createDirectEvent(rt, "onPulling"));
         return events;
     }
 };

--- a/src/js/MJRefreshNativeComponent.ts
+++ b/src/js/MJRefreshNativeComponent.ts
@@ -35,9 +35,6 @@ export interface NativeCommands {
     viewRef: React.ElementRef<MjRefreshControlType>
   ) => void
 }
-export const finishRefreshCommands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ["finishRefresh"],
-});
-export const beginRefreshCommands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ["beginRefresh"],
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ["finishRefresh", "beginRefresh"],
 });


### PR DESCRIPTION
# Summary

- 适配0.77，处理tsx文件无法问题以及事件名称定义规格对齐。

## Test Plan

<img width="423" height="892" alt="image" src="https://github.com/user-attachments/assets/b289fdb3-3393-473a-b7ce-27f6c978e5d5" />

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
