### PR TITLE
fix：修复RefreshNodeDelegate命名冲突编译报错

### DIFF
--- a/harmony/mjrefresh/src/main/cpp/MjRefreshComponentInstance.h
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshComponentInstance.h
@@ -32,7 +32,7 @@
 
 
 namespace rnoh {
-    class MjRefreshComponentInstance: public CppComponentInstance<facebook::react::MJRefreshShadowNode>, public RefreshNodeDelegate {
+    class MjRefreshComponentInstance: public CppComponentInstance<facebook::react::MJRefreshShadowNode>, public MjRefreshNodeDelegate {
     private:
         MjRefreshNode m_refreshNode;
         MjRefreshStackNode m_rowStyleNode;

--- a/harmony/mjrefresh/src/main/cpp/MjRefreshNode.cpp
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshNode.cpp
@@ -46,7 +46,7 @@ namespace rnoh {
         return *this;
     }
 
-    MjRefreshNode &MjRefreshNode::setRefreshNodeDelegate(RefreshNodeDelegate *refreshNodeDelegate) {
+    MjRefreshNode &MjRefreshNode::setRefreshNodeDelegate(MjRefreshNodeDelegate *refreshNodeDelegate) {
         m_refreshNodeDelegate = refreshNodeDelegate;
         return *this;
     }

--- a/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
+++ b/harmony/mjrefresh/src/main/cpp/MjRefreshNode.h
@@ -26,9 +26,9 @@
 #include "RNOH/arkui/NativeNodeApi.h"
 #include "RNOH/arkui/ArkUINode.h"
 
-class RefreshNodeDelegate {
+class MjRefreshNodeDelegate {
 public:
-    virtual ~RefreshNodeDelegate() = default;
+    virtual ~MjRefreshNodeDelegate() = default;
     virtual void onRefresh(){};
     virtual void pullRefreshStateChange(int32_t state, float_t percent){};
 };
@@ -36,7 +36,7 @@ public:
 namespace rnoh {
     class MjRefreshNode : public ArkUINode {
     protected:
-        RefreshNodeDelegate *m_refreshNodeDelegate;
+        MjRefreshNodeDelegate *m_refreshNodeDelegate;
         static constexpr float REFRESH_NODE_SIZE = 29;
         bool m_refreshingState = false; //是否触发正在刷新状态 
     public:
@@ -47,7 +47,7 @@ namespace rnoh {
         void removeChild(ArkUINode &child);
         void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs& eventArgs);
         MjRefreshNode &setNativeRefreshing(bool isRefreshing);
-        MjRefreshNode &setRefreshNodeDelegate(RefreshNodeDelegate *refreshNodeDelegate);
+        MjRefreshNode &setRefreshNodeDelegate(MjRefreshNodeDelegate *refreshNodeDelegate);
         MjRefreshNode &setRefreshContent(ArkUINode &refreshContent);
     };
 } // namespace rnoh


### PR DESCRIPTION
# Summary


- fix：修复RefreshNodeDelegate命名冲突编译报错
- Closed: #34 
- 
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.77.67
- DevEco Studio 6.0.1 Release
- Ohos_sdk_public 6.0.1.116 
- ROM: 6.0.0.130